### PR TITLE
Remove unused n_jobs parameter from Config

### DIFF
--- a/src/edaprep/config.py
+++ b/src/edaprep/config.py
@@ -346,7 +346,6 @@ class Config:
     # --- reproducibility / performance ------------------------------------------
     random_state: Optional[int] = None
     sample_size: Optional[int] = None
-    n_jobs: int = 1
     verbose: bool = False
 
     thresholds: Thresholds = field(default_factory=Thresholds)


### PR DESCRIPTION
Fixes #9。Config.n_jobs 全仓库没有任何代码读它,删掉这个 false promise。验证:grep 无残留、ruff check 通过、pytest 358 passed。