### PR TITLE
fix: account for cast-introduced missing values

### DIFF
--- a/src/edaprep/planning/rules.py
+++ b/src/edaprep/planning/rules.py
@@ -19,7 +19,7 @@ named, the reasoning is printed, and a user can override any of it per column.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Sequence
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -194,15 +194,27 @@ def _rule_drop_high_missing(cp: ColumnProfile, ctx: RuleContext) -> Optional[Dec
     if not ctx.config.drop_high_missing or cp.is_target:
         return None
     threshold = ctx.thresholds.missing_drop_threshold
-    if cp.missing_fraction < threshold:
+    cast_missing, missing_fraction = _post_cast_missing(cp, ctx)
+    if missing_fraction < threshold:
         return None
+    if cast_missing:
+        qualifier = "at least " if ctx.profile.sampling.get("used") else ""
+        found = (
+            f"{qualifier}{_pct(missing_fraction)} missing after {cast_missing} placeholder "
+            f"value(s) become NaN when the column is cast"
+        )
+    else:
+        found = f"{_pct(missing_fraction)} missing"
     return Decision(
         cp.name,
         Stage.DROP_COLUMNS,
         "drop",
-        params={"missing_fraction": round(cp.missing_fraction, 4)},
+        params={
+            "missing_fraction": round(missing_fraction, 4),
+            **({"cast_missing": cast_missing} if cast_missing else {}),
+        },
         rationale=(
-            f"{_pct(cp.missing_fraction)} missing, above the {_pct(threshold)} ceiling; "
+            f"{found}, above the {_pct(threshold)} ceiling; "
             f"imputing would invent most of the column"
         ),
         rule="drop_high_missing",
@@ -234,15 +246,27 @@ def _rule_missing_indicator(cp: ColumnProfile, ctx: RuleContext) -> Optional[Dec
     if cp.is_target or not ctx.config.add_missing_indicators:
         return None
     threshold = ctx.thresholds.missing_indicator_threshold
-    if cp.missing_fraction < threshold or cp.missing_fraction >= 1.0:
+    cast_missing, missing_fraction = _post_cast_missing(cp, ctx)
+    if missing_fraction < threshold or missing_fraction >= 1.0:
         return None
+    if cast_missing:
+        qualifier = "at least " if ctx.profile.sampling.get("used") else ""
+        found = (
+            f"{qualifier}{_pct(missing_fraction)} missing after {cast_missing} placeholder "
+            f"value(s) become NaN when the column is cast"
+        )
+    else:
+        found = f"{_pct(missing_fraction)} missing"
     return Decision(
         cp.name,
         Stage.MISSING_FLAG,
         "add_missing_indicator",
-        params={"missing_fraction": round(cp.missing_fraction, 4)},
+        params={
+            "missing_fraction": round(missing_fraction, 4),
+            **({"cast_missing": cast_missing} if cast_missing else {}),
+        },
         rationale=(
-            f"{_pct(cp.missing_fraction)} missing, above the {_pct(threshold)} flag "
+            f"{found}, above the {_pct(threshold)} flag "
             f"threshold; the flag is added before imputation, which would otherwise "
             f"destroy the signal"
         ),
@@ -333,6 +357,20 @@ def _cast_missing(cp: ColumnProfile, ctx: RuleContext) -> int:
     never to size the imputation, so a low count is safe.
     """
     return sum(ctx.profile.sentinels.get(cp.name, {}).values())
+
+
+def _post_cast_missing(cp: ColumnProfile, ctx: RuleContext) -> Tuple[int, float]:
+    """Count and fraction of raw missing cells plus placeholders cast to NaN.
+
+    ``ColumnProfile.n_missing`` and ``n_rows`` are measured on the full frame.  Sentinel
+    detection may use a sample, making ``cast_missing`` a lower bound, but its count is
+    still divided by the full-row denominator.  The resulting fraction is exact when
+    unsampled and a safe lower bound otherwise: it may miss a threshold crossing, but
+    cannot create a false one.
+    """
+    cast_missing = _cast_missing(cp, ctx)
+    missing_fraction = (cp.n_missing + cast_missing) / cp.n_rows if cp.n_rows else 0.0
+    return cast_missing, missing_fraction
 
 
 def _rule_impute(cp: ColumnProfile, ctx: RuleContext) -> Optional[Decision]:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 import edaprep
-from edaprep import AutoPipeline, Config, Pipeline
+from edaprep import AutoPipeline, Config, Pipeline, Thresholds
 from edaprep.exceptions import ConfigurationError, NotFittedError
 from edaprep.planning import Plan, Planner
 from edaprep.planning.rules import Rule, default_rules
@@ -651,6 +651,95 @@ def test_cast_introduced_nan_is_imputed() -> None:
         "the rationale must name the placeholder count rather than silently "
         "reporting 0% missing while imputing anyway"
     )
+
+
+def test_cast_introduced_nan_gets_missing_indicator() -> None:
+    """Cast-introduced gaps above the flag threshold retain their missingness signal."""
+    gen = np.random.default_rng(17)
+    n = 300
+    charges = [f"{value:.2f}" for value in gen.uniform(20, 8000, size=n)]
+    for index in range(24):  # 8%, above the 5% flag threshold
+        charges[index] = " "
+    frame = pd.DataFrame(
+        {
+            "total_charges": charges,
+            "tenure": gen.integers(1, 72, size=n),
+            "churn": gen.integers(0, 2, size=n),
+        }
+    )
+    assert frame["total_charges"].isna().sum() == 0, "blanks are strings, not NaN"
+
+    pipe = AutoPipeline(target="churn", model_family="linear", random_state=0)
+    out = pipe.fit_transform(frame)
+
+    decisions = [d for d in pipe.plan_.decisions if d.column == "total_charges"]
+    indicator = next(d for d in decisions if d.action == "add_missing_indicator")
+    assert indicator.params["cast_missing"] == 24
+    assert indicator.params["missing_fraction"] == pytest.approx(0.08)
+    assert "placeholder" in indicator.rationale
+    assert "8.0% missing" in indicator.rationale
+    assert "total_charges__was_missing" in out.columns
+    assert out["total_charges__was_missing"].sum() == 24
+    assert out["total_charges"].isna().sum() == 0
+
+
+def test_cast_introduced_nan_high_missing_is_dropped() -> None:
+    """A conservative post-cast lower bound can safely trigger the drop threshold."""
+    gen = np.random.default_rng(19)
+    n = 300
+    charges = [f"{value:.2f}" for value in gen.uniform(20, 8000, size=n)]
+    for index in range(210):  # 70%, above the 60% drop threshold
+        charges[index] = " "
+    frame = pd.DataFrame(
+        {
+            "total_charges": charges,
+            "tenure": gen.integers(1, 72, size=n),
+            "churn": gen.integers(0, 2, size=n),
+        }
+    )
+    assert frame["total_charges"].isna().sum() == 0, "blanks are strings, not NaN"
+
+    pipe = AutoPipeline(target="churn", model_family="linear", random_state=0)
+    out = pipe.fit_transform(frame)
+
+    decisions = [d for d in pipe.plan_.decisions if d.column == "total_charges"]
+    drop = next(d for d in decisions if d.action == "drop")
+    assert drop.params["cast_missing"] == 210
+    assert drop.params["missing_fraction"] == pytest.approx(0.70)
+    assert "placeholder" in drop.rationale
+    assert "70.0% missing" in drop.rationale
+    assert "total_charges" not in out.columns
+
+
+def test_sampled_sentinel_count_uses_full_row_denominator() -> None:
+    """An over-representative sentinel sample must not create a false drop."""
+    n = 100
+    frame = pd.DataFrame(
+        {
+            "total_charges": [f"{value:.2f}" for value in np.linspace(20, 8000, n)],
+            "churn": np.resize([0, 1], n),
+        }
+    )
+    config = Config(
+        random_state=0,
+        sample_size=20,
+        thresholds=Thresholds(sampling_row_threshold=10, sample_size=20),
+    )
+    # Make 75% of the deterministic sample placeholders but only 15% of the full frame.
+    sampled_indexes = frame.sample(n=20, random_state=0).index
+    frame.loc[sampled_indexes[:15], "total_charges"] = " "
+
+    dataset_profile = profile(frame, target="churn", config=config)
+    plan = Planner(config).plan(dataset_profile)
+    decisions = [d for d in plan.decisions if d.column == "total_charges"]
+
+    assert dataset_profile.sampling["used"]
+    assert sum(dataset_profile.sentinels["total_charges"].values()) == 15
+    assert not any(d.action == "drop" for d in decisions)
+    indicator = next(d for d in decisions if d.action == "add_missing_indicator")
+    assert indicator.params["cast_missing"] == 15
+    assert indicator.params["missing_fraction"] == pytest.approx(0.15)
+    assert indicator.rationale.startswith("at least 15.0% missing")
 
 
 def test_cast_introduced_nan_imputed_on_unseen_test_rows() -> None:


### PR DESCRIPTION
## What this changes

Fixes #14 by making missing-indicator and high-missing planning rules account for sentinel values that become missing during type casting. Sampling remains conservative: sampled sentinel counts use the full DataFrame row count, so the rule can miss work but cannot overstate missingness and drop a column incorrectly.

## Checklist

- [x] `pytest` passes
- [x] `ruff check src/ tests/ benchmarks/ examples/` passes
- [x] Added tests for the behaviour that changed
- [x] Confirmed the new regression tests fail without the fix

## Validation

- `python -m pytest -q -p no:cacheprovider`
- `python -m ruff check src/ tests/ benchmarks/ examples/`
- `python -m pip check`

## AI assistance disclosure

This patch was developed with GPT Web/Codex assistance, then locally inspected and validated. This disclosure does not claim human review.