### PR TITLE
ci: normalise line endings with .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Normalise line endings on the way into the repository.
+#
+# Without this, a contributor whose editor writes CRLF produces a diff in which
+# every line of every file they touched appears changed.  It happened in #21: a
+# thirteen-line change arrived as +419/-406 and buried the actual edit.
+#
+# `text=auto` stores everything with LF in git and checks it out native, so a
+# Windows contributor still gets CRLF in their working tree and commits LF.
+
+* text=auto
+
+# Files that must keep LF even on Windows checkouts, because something other
+# than git reads them: shell scripts run by CI, and anything a container mounts.
+*.sh        text eol=lf
+*.yml       text eol=lf
+*.yaml      text eol=lf
+
+# Python, docs and config: normalised, native on checkout.
+*.py        text
+*.md        text
+*.toml      text
+*.cfg       text
+*.txt       text
+*.json      text
+
+# Never touched.
+*.png       binary
+*.jpg       binary
+*.ico       binary
+*.parquet   binary
+*.pyc       binary


### PR DESCRIPTION
Prompted by #21, where a thirteen-line change arrived as `+419/-406` because the contributor's editor converted both files from LF to CRLF:

```console
$ git diff main...pr21 --stat
 2 files changed, 419 insertions(+), 406 deletions(-)

$ git diff main...pr21 --ignore-cr-at-eol --stat
 2 files changed, 13 insertions(+)
```

The real edit was invisible, and merging it would have wiped `git blame` across the entire README.

Nothing in the repo was preventing this, which makes it the project's bug rather than the contributor's. `text=auto` stores LF in git and checks out native, so a Windows contributor still gets CRLF in their working tree while committing LF — without configuring anything or knowing this was ever a problem.

Workflow and shell files are pinned to `eol=lf` explicitly, since CI reads them on Linux where a stray CR in a `run:` block fails in a genuinely confusing way.

No effect on existing files until they are next touched.