### PR TITLE
docs: make PRs link to the issues they close

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,12 @@
 
 Closes #
 
+<!-- Keep the line above and put the issue number on it, even if you rewrite the rest
+     of this template. "Closes #5" links the PR to the issue and closes it on merge;
+     "Per #5" or "Fixes issue 5" look identical to a human and do neither, which
+     leaves the issue looking unclaimed and invites somebody to duplicate your work.
+     If this PR is not tied to an issue, delete the line. -->
+
 ## Checklist
 
 - [ ] `pytest` passes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,10 @@ optimise, and be willing to delete.
 ## Pull requests
 
 - Branch from `main`.
+- **Put `Closes #123` in the PR description** when the PR resolves an issue. It has
+  to be a real closing keyword — `Closes`, `Fixes`, `Resolves` — because `Per #123`
+  reads the same to a person and links nothing, leaving the issue looking unclaimed
+  and inviting somebody to duplicate your work.
 - One logical change per PR. A refactor and a fix in the same diff is two PRs.
 - Commit messages: `feat:`, `fix:`, `perf:`, `docs:`, `test:`, `ci:`, `refactor:`.
   Explain **why** in the body, not just what — the git log is documentation.


### PR DESCRIPTION
Closes nothing — process fix prompted by #21.

The PR template already carried a `Closes #` line. #21 replaced the body with its own structure and the line went with it; the description said `Per #5`, which reads identically to a human and is not a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).

Consequence: #5 kept showing as unclaimed while someone had an open PR against it. That is the same failure mode that cost somebody an evening on #14 — and it nearly repeated on #18, where a third contributor asked to start work thirteen minutes after it was claimed.

- **Template** now explains *why* the line matters instead of just offering it. A bare `Closes #` is the easiest thing to delete while rewriting a description; a comment saying what breaks is harder to ignore.
- **CONTRIBUTING** names the three keywords that actually work and says what goes wrong with the ones that do not.