### PR TITLE
Enforce ruff format in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           python-version: "3.12"
       - run: python -m pip install ruff
       - run: ruff check src/ tests/ benchmarks/ examples/
-      - run: ruff format --check --diff src/ tests/ || true  # advisory: not yet enforced
+      - run: ruff format --check --diff src/ tests/ benchmarks/ examples/
 
   package:
     name: build and verify the distribution

--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -159,6 +159,7 @@ def bench_profiling(rows: int, repeat: int) -> List[Result]:
     frame = make_frame(rows)
 
     seconds, peak = measure(lambda: profile(frame, target="target"), repeat)
+
     # The nearest hand-written equivalent: the statistics an EDA notebook actually
     # computes, column by column.
     def baseline() -> Dict[str, object]:
@@ -195,9 +196,7 @@ def bench_profiling(rows: int, repeat: int) -> List[Result]:
         lambda: profile(frame, target="target", compute_moments=False, check_quality=False),
         repeat,
     )
-    results.append(
-        Result("profile(quick)", "profiling", seconds, peak, rows, frame.shape[1])
-    )
+    results.append(Result("profile(quick)", "profiling", seconds, peak, rows, frame.shape[1]))
     return results
 
 
@@ -447,9 +446,7 @@ def bench_pipelines(rows: int, repeat: int) -> List[Result]:
                                     ("impute", SimpleImputer(strategy="most_frequent")),
                                     (
                                         "encode",
-                                        SkOneHot(
-                                            handle_unknown="ignore", sparse_output=False
-                                        ),
+                                        SkOneHot(handle_unknown="ignore", sparse_output=False),
                                     ),
                                 ]
                             ),

--- a/examples/end_to_end.py
+++ b/examples/end_to_end.py
@@ -148,19 +148,25 @@ def main() -> None:
     report = eda.analyze("standard")
 
     print("Numerical summary (most-skewed first):")
-    print(report.numerical[
-        ["column", "missing_%", "mean", "median", "skew", "n_zeros", "distribution"]
-    ].to_string(index=False))
+    print(
+        report.numerical[
+            ["column", "missing_%", "mean", "median", "skew", "n_zeros", "distribution"]
+        ].to_string(index=False)
+    )
 
     print("\nCategorical summary:")
-    print(report.categorical[
-        ["column", "n_unique", "modal_value", "modal_%", "n_rare_levels", "note"]
-    ].to_string(index=False))
+    print(
+        report.categorical[
+            ["column", "n_unique", "modal_value", "modal_%", "n_rare_levels", "note"]
+        ].to_string(index=False)
+    )
 
     print("\nOutliers -- the three fences disagree, which is the point:")
-    print(report.outliers[
-        ["column", "skew", "n_iqr", "n_zscore", "n_modified_z", "recommended"]
-    ].to_string(index=False))
+    print(
+        report.outliers[
+            ["column", "skew", "n_iqr", "n_zscore", "n_modified_z", "recommended"]
+        ].to_string(index=False)
+    )
 
     print("\nFeature/target association:")
     print(report.target_relationships.head(8).to_string(index=False))
@@ -178,7 +184,7 @@ def main() -> None:
     rule("5. THE PLAN  -- decided before a single row is touched")
     config = edaprep.Config(random_state=42)
     config.column("satisfaction_rating").semantic_type = "ordinal"
-    config.column("account_balance").outlier_strategy = "clip"   # a user override
+    config.column("account_balance").outlier_strategy = "clip"  # a user override
 
     pipe = edaprep.AutoPipeline(
         target="churn", model_family="linear", config=config, random_state=42
@@ -209,8 +215,10 @@ def main() -> None:
     print(f"identical columns:      {list(X_train.columns) == list(X_test.columns)}")
     all_numeric = all(pd.api.types.is_numeric_dtype(d) for d in X_train.dtypes)
     print(f"all numeric:            {all_numeric}")
-    print(f"missing values left:    {int(X_train.isna().sum().sum())} train, "
-          f"{int(X_test.isna().sum().sum())} test")
+    print(
+        f"missing values left:    {int(X_train.isna().sum().sum())} train, "
+        f"{int(X_test.isna().sum().sum())} test"
+    )
     print(f"target absent from X:   {'churn' not in X_train.columns}")
 
     print("\nfinal columns:")

--- a/src/edaprep/backends/base.py
+++ b/src/edaprep/backends/base.py
@@ -118,15 +118,11 @@ class Backend(ABC):
         """Quantile matrix of shape ``(len(levels), len(columns))``."""
 
     @abstractmethod
-    def group_mean(
-        self, frame: Any, value_column: str, group_column: str
-    ) -> Dict[Any, float]:
+    def group_mean(self, frame: Any, value_column: str, group_column: str) -> Dict[Any, float]:
         """Mean of ``value_column`` per level of ``group_column``."""
 
     @abstractmethod
-    def duplicated_rows(
-        self, frame: Any, subset: Optional[Sequence[str]] = None
-    ) -> np.ndarray:
+    def duplicated_rows(self, frame: Any, subset: Optional[Sequence[str]] = None) -> np.ndarray:
         """Boolean array: True where the row repeats an earlier one."""
 
     # -- construction --------------------------------------------------------------------

--- a/src/edaprep/backends/pandas_backend.py
+++ b/src/edaprep/backends/pandas_backend.py
@@ -109,9 +109,7 @@ class PandasBackend(Backend):
             return frame.duplicated(subset=list(subset) if subset else None).to_numpy()
         except TypeError:
             return (
-                frame.astype(str)
-                .duplicated(subset=list(subset) if subset else None)
-                .to_numpy()
+                frame.astype(str).duplicated(subset=list(subset) if subset else None).to_numpy()
             )
 
     # -- construction --------------------------------------------------------------------

--- a/src/edaprep/core/base.py
+++ b/src/edaprep/core/base.py
@@ -227,8 +227,7 @@ class Transformer(ABC):
     ) -> FitContext:
         if not isinstance(X, pd.DataFrame):
             raise TypeError(
-                f"{type(self).__name__}.fit expects a pandas DataFrame, got "
-                f"{type(X).__name__}."
+                f"{type(self).__name__}.fit expects a pandas DataFrame, got {type(X).__name__}."
             )
         if self.uses_target and y is None:
             raise LeakageError.target_required(type(self).__name__)

--- a/src/edaprep/core/pipeline.py
+++ b/src/edaprep/core/pipeline.py
@@ -226,9 +226,7 @@ class Pipeline(Transformer):
         self._context_ = context
         return super().fit_transform(X, y, context)
 
-    def transform(
-        self, X: pd.DataFrame, context: Optional[FitContext] = None
-    ) -> pd.DataFrame:
+    def transform(self, X: pd.DataFrame, context: Optional[FitContext] = None) -> pd.DataFrame:
         check_is_fitted(self)
         context = context or getattr(self, "_context_", None) or FitContext(config=self.config)
         # Only the most recent transform is described in the report; otherwise calling
@@ -437,9 +435,7 @@ class AutoPipeline(Pipeline):
         self.report_ = self.report()
         return out
 
-    def transform(
-        self, X: pd.DataFrame, context: Optional[FitContext] = None
-    ) -> pd.DataFrame:
+    def transform(self, X: pd.DataFrame, context: Optional[FitContext] = None) -> pd.DataFrame:
         out = super().transform(X, context)
         self.report_ = self.report()
         return out
@@ -497,9 +493,7 @@ class AutoPipeline(Pipeline):
                     "rule": d.rule,
                     "source": d.source,
                 }
-                for d in sorted(
-                    self.plan_.decisions, key=lambda d: (d.column, d.stage.order)
-                )
+                for d in sorted(self.plan_.decisions, key=lambda d: (d.column, d.stage.order))
             ]
         )
 

--- a/src/edaprep/eda/analyzer.py
+++ b/src/edaprep/eda/analyzer.py
@@ -137,9 +137,7 @@ class EDAReport:
         if self.issues:
             parts.append("<h2>Findings</h2>")
             for issue in sorted(self.issues, key=lambda i: -i.severity.rank):
-                parts.append(
-                    f"<div class='w {_e(issue.severity)}'>{_e(issue.message)}</div>"
-                )
+                parts.append(f"<div class='w {_e(issue.severity)}'>{_e(issue.message)}</div>")
         parts.append("</main>")
         html = "\n".join(parts)
         if path:
@@ -262,9 +260,7 @@ class EDA:
     def profile_(self) -> DatasetProfile:
         """The profile, computed once and reused."""
         if self._profile is None:
-            self._profile = profile_dataset(
-                self.data, target=self.target, config=self.config
-            )
+            self._profile = profile_dataset(self.data, target=self.target, config=self.config)
         return self._profile
 
     def analyze(

--- a/src/edaprep/eda/categorical.py
+++ b/src/edaprep/eda/categorical.py
@@ -72,9 +72,7 @@ def categorical_summary(
 def _note(cp, high_cardinality: int, n_rare: int) -> str:
     notes = []
     if cp.n_unique > high_cardinality:
-        notes.append(
-            f"high cardinality: one-hot would add {cp.n_unique} columns"
-        )
+        notes.append(f"high cardinality: one-hot would add {cp.n_unique} columns")
     if cp.is_near_constant:
         notes.append(f"near-constant ({cp.modal_frequency:.1%} one value)")
     if n_rare:

--- a/src/edaprep/eda/correlation.py
+++ b/src/edaprep/eda/correlation.py
@@ -133,9 +133,7 @@ def variance_inflation(
 
     # copy=True for the same reason as in preprocessing/selection.py: pandas 2.3+
     # returns a read-only view, and `fill_diagonal` writes in place.
-    corr = frame.corr(method="pearson", numeric_only=True).to_numpy(
-        dtype=np.float64, copy=True
-    )
+    corr = frame.corr(method="pearson", numeric_only=True).to_numpy(dtype=np.float64, copy=True)
     corr = np.nan_to_num(corr, nan=0.0)
     np.fill_diagonal(corr, 1.0)
 

--- a/src/edaprep/eda/numerical.py
+++ b/src/edaprep/eda/numerical.py
@@ -78,9 +78,7 @@ def numerical_summary(
         return frame
     # Most-skewed first: those are the columns a reader most needs to look at.
     frame["_sort"] = frame["skew"].abs().fillna(-1)
-    frame = frame.sort_values("_sort", ascending=False, ignore_index=True).drop(
-        columns="_sort"
-    )
+    frame = frame.sort_values("_sort", ascending=False, ignore_index=True).drop(columns="_sort")
     numeric_cols = frame.select_dtypes(include="number").columns
     frame[numeric_cols] = frame[numeric_cols].round(4)
     return frame

--- a/src/edaprep/eda/target.py
+++ b/src/edaprep/eda/target.py
@@ -30,9 +30,7 @@ from ..types import NUMERIC_LIKE, SemanticType
 __all__ = ["target_summary", "target_relationships", "benjamini_hochberg"]
 
 
-def target_summary(
-    data: pd.DataFrame, profile: DatasetProfile, target: str
-) -> Dict[str, Any]:
+def target_summary(data: pd.DataFrame, profile: DatasetProfile, target: str) -> Dict[str, Any]:
     """Distribution of the target, plus the imbalance measurement."""
     series = data[target]
     out: Dict[str, Any] = {
@@ -121,9 +119,7 @@ def target_relationships(
             "column": name,
             "semantic": str(cp.semantic),
             "association": (
-                round(cp.target_association, 4)
-                if cp.target_association is not None
-                else None
+                round(cp.target_association, 4) if cp.target_association is not None else None
             ),
             "measure": cp.target_association_kind,
         }
@@ -145,9 +141,7 @@ def target_relationships(
         frame["p_value"] = frame["p_value"].round(6)
 
     frame["_sort"] = frame["association"].fillna(-1)
-    return frame.sort_values("_sort", ascending=False, ignore_index=True).drop(
-        columns="_sort"
-    )
+    return frame.sort_values("_sort", ascending=False, ignore_index=True).drop(columns="_sort")
 
 
 def _test(

--- a/src/edaprep/planning/decisions.py
+++ b/src/edaprep/planning/decisions.py
@@ -169,9 +169,7 @@ class Plan:
     @property
     def decisions(self) -> List[Decision]:
         """Every decision, including the ones that resolved to doing nothing."""
-        return [d for step in self.steps for d in step.decisions] + list(
-            self.noop_decisions
-        )
+        return [d for step in self.steps for d in step.decisions] + list(self.noop_decisions)
 
     def for_column(self, column: str) -> List[Decision]:
         """Every decision affecting ``column``, in stage order."""
@@ -199,9 +197,7 @@ class Plan:
 
     @property
     def uses_target(self) -> bool:
-        return any(
-            d.action in ("encode_target",) for d in self.decisions
-        )
+        return any(d.action in ("encode_target",) for d in self.decisions)
 
     # -- editing --------------------------------------------------------------------
 
@@ -252,9 +248,7 @@ class Plan:
     def from_dict(cls, data: Dict[str, Any]) -> "Plan":
         return cls(
             steps=tuple(PlannedStep.from_dict(s) for s in data.get("steps", ())),
-            noop_decisions=tuple(
-                Decision.from_dict(d) for d in data.get("noop_decisions", ())
-            ),
+            noop_decisions=tuple(Decision.from_dict(d) for d in data.get("noop_decisions", ())),
             target=data.get("target"),
             model_family=data.get("model_family"),
             dropped_columns=dict(data.get("dropped_columns", {})),

--- a/src/edaprep/planning/planner.py
+++ b/src/edaprep/planning/planner.py
@@ -92,9 +92,7 @@ class Planner:
         # DROP_COLUMNS first: a dropped column takes no further part in planning, which
         # keeps the plan free of steps that operate on columns that will not exist.
         for name in feature_columns:
-            decision = self.rules.decide(
-                Stage.DROP_COLUMNS, profile.columns[name], context
-            )
+            decision = self.rules.decide(Stage.DROP_COLUMNS, profile.columns[name], context)
             if decision is not None and decision.action == "drop":
                 dropped[name] = decision.rationale
                 decisions_by_stage.setdefault(Stage.DROP_COLUMNS, []).append(decision)
@@ -259,9 +257,7 @@ class Planner:
             columns = ()
 
         if stage is Stage.OUTLIERS:
-            params["per_column_method"] = {
-                d.column: d.params.get("method") for d in decisions
-            }
+            params["per_column_method"] = {d.column: d.params.get("method") for d in decisions}
             params["per_column_strategy"] = {
                 d.column: d.params.get("strategy") for d in decisions
             }
@@ -277,9 +273,7 @@ class Planner:
             params["threshold"] = decisions[0].params.get("threshold")
         elif stage is Stage.DATETIME:
             explicit = {
-                d.column: d.params["features"]
-                for d in decisions
-                if d.params.get("features")
+                d.column: d.params["features"] for d in decisions if d.params.get("features")
             }
             if explicit:
                 params["per_column_features"] = explicit

--- a/src/edaprep/planning/rules.py
+++ b/src/edaprep/planning/rules.py
@@ -61,9 +61,7 @@ class Rule:
     priority: int = 0
     description: str = ""
 
-    def __call__(
-        self, column: ColumnProfile, context: RuleContext
-    ) -> Optional[Decision]:
+    def __call__(self, column: ColumnProfile, context: RuleContext) -> Optional[Decision]:
         return self.decide(column, context)
 
     def __repr__(self) -> str:
@@ -156,7 +154,8 @@ def _rule_drop_constant(cp: ColumnProfile, ctx: RuleContext) -> Optional[Decisio
         "drop",
         params={"n_unique": cp.n_unique},
         rationale=(
-            "entirely missing" if cp.missing_fraction == 1.0
+            "entirely missing"
+            if cp.missing_fraction == 1.0
             else f"constant ({cp.n_unique} distinct value)"
         ),
         rule="drop_constant",
@@ -226,7 +225,7 @@ def _rule_drop_high_missing(cp: ColumnProfile, ctx: RuleContext) -> Optional[Dec
         "drop",
         params={
             "missing_fraction": round(cp.missing_fraction, 4),
-            **( {"cast_missing": cast_missing} if cast_missing else {} ),
+            **({"cast_missing": cast_missing} if cast_missing else {}),
         },
         rationale=(
             f"{found}, above the {_pct(threshold)} ceiling; "
@@ -287,7 +286,7 @@ def _rule_missing_indicator(cp: ColumnProfile, ctx: RuleContext) -> Optional[Dec
         "add_missing_indicator",
         params={
             "missing_fraction": round(cp.missing_fraction, 4),
-            **( {"cast_missing": cast_missing} if cast_missing else {} ),
+            **({"cast_missing": cast_missing} if cast_missing else {}),
         },
         rationale=(
             f"{found}, above the {_pct(threshold)} flag "
@@ -344,11 +343,16 @@ def _rule_outliers(cp: ColumnProfile, ctx: RuleContext) -> Optional[Decision]:
     if strategy == AUTO:
         # Conservative by design: an unusual value is not evidence of an error, and the
         # brief is explicit that detection and removal are different decisions.
-        strategy = "clip" if ctx.model_family in (
-            ModelFamily.LINEAR,
-            ModelFamily.DISTANCE,
-            ModelFamily.NEURAL,
-        ) else "report"
+        strategy = (
+            "clip"
+            if ctx.model_family
+            in (
+                ModelFamily.LINEAR,
+                ModelFamily.DISTANCE,
+                ModelFamily.NEURAL,
+            )
+            else "report"
+        )
 
     return Decision(
         cp.name,
@@ -574,8 +578,7 @@ def _rule_transform(cp: ColumnProfile, ctx: RuleContext) -> Optional[Decision]:
     notes = ()
     if cp.has_zero and method == "log1p":
         notes = (
-            f"{cp.numeric.n_zeros} zero value(s) map to 0 under log1p, which is "
-            f"well defined",
+            f"{cp.numeric.n_zeros} zero value(s) map to 0 under log1p, which is well defined",
         )
 
     return Decision(
@@ -867,39 +870,104 @@ def default_rules() -> RuleSet:
     return RuleSet(
         [
             # DROP_COLUMNS
-            Rule("user_drop", Stage.DROP_COLUMNS, _rule_user_drop, priority=100,
-                 description="Honour config.column(name).drop = True"),
-            Rule("drop_constant", Stage.DROP_COLUMNS, _rule_drop_constant, priority=90,
-                 description="Remove columns with a single distinct value"),
-            Rule("drop_identifier", Stage.DROP_COLUMNS, _rule_drop_identifier, priority=80,
-                 description="Remove row keys, which cannot generalise"),
-            Rule("drop_high_missing", Stage.DROP_COLUMNS, _rule_drop_high_missing, priority=70,
-                 description="Remove columns too sparse to impute honestly"),
-            Rule("drop_text", Stage.DROP_COLUMNS, _rule_drop_text, priority=60,
-                 description="Remove free-text columns, which v1 does not vectorise"),
+            Rule(
+                "user_drop",
+                Stage.DROP_COLUMNS,
+                _rule_user_drop,
+                priority=100,
+                description="Honour config.column(name).drop = True",
+            ),
+            Rule(
+                "drop_constant",
+                Stage.DROP_COLUMNS,
+                _rule_drop_constant,
+                priority=90,
+                description="Remove columns with a single distinct value",
+            ),
+            Rule(
+                "drop_identifier",
+                Stage.DROP_COLUMNS,
+                _rule_drop_identifier,
+                priority=80,
+                description="Remove row keys, which cannot generalise",
+            ),
+            Rule(
+                "drop_high_missing",
+                Stage.DROP_COLUMNS,
+                _rule_drop_high_missing,
+                priority=70,
+                description="Remove columns too sparse to impute honestly",
+            ),
+            Rule(
+                "drop_text",
+                Stage.DROP_COLUMNS,
+                _rule_drop_text,
+                priority=60,
+                description="Remove free-text columns, which v1 does not vectorise",
+            ),
             # DATETIME
-            Rule("expand_datetime", Stage.DATETIME, _rule_datetime, priority=50,
-                 description="Expand datetimes into varying calendar features"),
+            Rule(
+                "expand_datetime",
+                Stage.DATETIME,
+                _rule_datetime,
+                priority=50,
+                description="Expand datetimes into varying calendar features",
+            ),
             # MISSING_FLAG
-            Rule("missing_indicator", Stage.MISSING_FLAG, _rule_missing_indicator, priority=50,
-                 description="Flag missingness before imputation destroys it"),
+            Rule(
+                "missing_indicator",
+                Stage.MISSING_FLAG,
+                _rule_missing_indicator,
+                priority=50,
+                description="Flag missingness before imputation destroys it",
+            ),
             # OUTLIERS
-            Rule("outlier_method_by_skew", Stage.OUTLIERS, _rule_outliers, priority=50,
-                 description="Choose the fence from measured skewness (axis 3)"),
+            Rule(
+                "outlier_method_by_skew",
+                Stage.OUTLIERS,
+                _rule_outliers,
+                priority=50,
+                description="Choose the fence from measured skewness (axis 3)",
+            ),
             # MISSING
-            Rule("impute_by_type", Stage.MISSING, _rule_impute, priority=50,
-                 description="Median for numeric, mode or explicit category otherwise"),
+            Rule(
+                "impute_by_type",
+                Stage.MISSING,
+                _rule_impute,
+                priority=50,
+                description="Median for numeric, mode or explicit category otherwise",
+            ),
             # TRANSFORM
-            Rule("transform_by_skew", Stage.TRANSFORM, _rule_transform, priority=50,
-                 description="Skew tiering with support validation (axis 1)"),
+            Rule(
+                "transform_by_skew",
+                Stage.TRANSFORM,
+                _rule_transform,
+                priority=50,
+                description="Skew tiering with support validation (axis 1)",
+            ),
             # RARE_CATEGORY
-            Rule("group_rare", Stage.RARE_CATEGORY, _rule_rare_category, priority=50,
-                 description="Collapse levels too rare to estimate"),
+            Rule(
+                "group_rare",
+                Stage.RARE_CATEGORY,
+                _rule_rare_category,
+                priority=50,
+                description="Collapse levels too rare to estimate",
+            ),
             # ENCODE
-            Rule("encode_by_cardinality_and_family", Stage.ENCODE, _rule_encode, priority=50,
-                 description="Route by cardinality and model family (axis 2)"),
+            Rule(
+                "encode_by_cardinality_and_family",
+                Stage.ENCODE,
+                _rule_encode,
+                priority=50,
+                description="Route by cardinality and model family (axis 2)",
+            ),
             # SCALE
-            Rule("scale_by_family", Stage.SCALE, _rule_scale, priority=50,
-                 description="Scale only when the model family needs it"),
+            Rule(
+                "scale_by_family",
+                Stage.SCALE,
+                _rule_scale,
+                priority=50,
+                description="Scale only when the model family needs it",
+            ),
         ]
     )

--- a/src/edaprep/preprocessing/casting.py
+++ b/src/edaprep/preprocessing/casting.py
@@ -81,9 +81,7 @@ class DataTypeInference(Transformer, ColumnTransformerMixin):
                 actions: List[str] = []
                 series = X[column]
                 cp = context.column_profile(column)
-                is_stringy = series.dtype == object or isinstance(
-                    series.dtype, pd.StringDtype
-                )
+                is_stringy = series.dtype == object or isinstance(series.dtype, pd.StringDtype)
 
                 if is_stringy and self.strip_whitespace:
                     actions.append("strip")
@@ -164,15 +162,11 @@ class DataTypeInference(Transformer, ColumnTransformerMixin):
                 target = self.target_dtypes_.get(column)
                 if "to_numeric" in actions:
                     parsed = pd.to_numeric(series, errors="coerce")
-                    counts["failed_to_parse"] = int(
-                        (series.notna() & parsed.isna()).sum()
-                    )
+                    counts["failed_to_parse"] = int((series.notna() & parsed.isna()).sum())
                     series = parsed
                 elif "to_datetime" in actions:
                     parsed = pd.to_datetime(series, errors="coerce", format="mixed")
-                    counts["failed_to_parse"] = int(
-                        (series.notna() & parsed.isna()).sum()
-                    )
+                    counts["failed_to_parse"] = int((series.notna() & parsed.isna()).sum())
                     series = parsed
                 elif "to_boolean" in actions:
                     series = _to_boolean(series)

--- a/src/edaprep/preprocessing/datetime_features.py
+++ b/src/edaprep/preprocessing/datetime_features.py
@@ -191,9 +191,7 @@ class DateTimeExpander(Transformer, ColumnTransformerMixin):
 
     def _compute_feature_names_out(self) -> List[str]:
         names = [
-            c
-            for c in self.feature_names_in_
-            if not (self.drop_original and c in self.emitted_)
+            c for c in self.feature_names_in_ if not (self.drop_original and c in self.emitted_)
         ]
         for column, features in self.emitted_.items():
             names.extend(f"{column}__{f}" for f in features)

--- a/src/edaprep/preprocessing/encoding.py
+++ b/src/edaprep/preprocessing/encoding.py
@@ -164,9 +164,7 @@ class RareCategoryGrouper(_CategoricalBase):
             timer.params = {"threshold": self.threshold, "other_label": self.other_label}
             timer.effect = {
                 "n_categories_grouped": dict(self.n_grouped_),
-                "n_categories_kept": {
-                    c: len(v) for c, v in self.kept_categories_.items()
-                },
+                "n_categories_kept": {c: len(v) for c, v in self.kept_categories_.items()},
             }
 
     def _transform(self, X: pd.DataFrame, context: FitContext) -> pd.DataFrame:
@@ -289,9 +287,7 @@ class OneHotEncoder(_CategoricalBase):
 
                 known_codes = {c for c in wanted_codes if c >= 0}
                 n_unknown = int(
-                    np.count_nonzero(
-                        (codes >= 0) & ~np.isin(codes, list(known_codes) or [-2])
-                    )
+                    np.count_nonzero((codes >= 0) & ~np.isin(codes, list(known_codes) or [-2]))
                 )
                 if n_unknown:
                     unknown_counts[column] = n_unknown
@@ -330,9 +326,7 @@ class OneHotEncoder(_CategoricalBase):
                 "n_unknown_values": unknown_counts,
             }
 
-        remaining = {
-            str(c): X[c] for c in X.columns if str(c) not in self.categories_
-        }
+        remaining = {str(c): X[c] for c in X.columns if str(c) not in self.categories_}
         return pd.DataFrame({**remaining, **added}, index=X.index, copy=False)
 
     def _compute_feature_names_out(self) -> List[str]:
@@ -375,9 +369,10 @@ class OrdinalEncoder(_CategoricalBase):
                     ordered = list(self.categories[column])  # user-supplied ordering
                 else:
                     series = self._as_object(X[column])
-                    if isinstance(X[column].dtype, pd.CategoricalDtype) and X[
-                        column
-                    ].dtype.ordered:
+                    if (
+                        isinstance(X[column].dtype, pd.CategoricalDtype)
+                        and X[column].dtype.ordered
+                    ):
                         # An ordered categorical already states the ordering; honouring
                         # it is the whole point of the dtype.
                         ordered = list(X[column].cat.categories)
@@ -387,9 +382,7 @@ class OrdinalEncoder(_CategoricalBase):
                 self.mappings_[column] = {c: i for i, c in enumerate(ordered)}
 
             timer.columns = list(self.columns_)
-            timer.effect = {
-                "n_categories": {c: len(v) for c, v in self.categories_.items()}
-            }
+            timer.effect = {"n_categories": {c: len(v) for c, v in self.categories_.items()}}
 
     def _transform(self, X: pd.DataFrame, context: FitContext) -> pd.DataFrame:
         replacements: Dict[str, pd.Series] = {}
@@ -459,9 +452,7 @@ class FrequencyEncoder(_CategoricalBase):
                 self.frequencies_[column] = counts.to_dict()
             timer.columns = list(self.columns_)
             timer.params = {"normalize": self.normalize}
-            timer.effect = {
-                "n_categories": {c: len(v) for c, v in self.frequencies_.items()}
-            }
+            timer.effect = {"n_categories": {c: len(v) for c, v in self.frequencies_.items()}}
 
     def _transform(self, X: pd.DataFrame, context: FitContext) -> pd.DataFrame:
         replacements: Dict[str, pd.Series] = {}
@@ -525,9 +516,7 @@ class TargetEncoder(_CategoricalBase):
         is the convention that makes the encoding read as "probability of the positive
         class" for imbalanced problems.
         """
-        if pd.api.types.is_numeric_dtype(y.dtype) and not pd.api.types.is_bool_dtype(
-            y.dtype
-        ):
+        if pd.api.types.is_numeric_dtype(y.dtype) and not pd.api.types.is_bool_dtype(y.dtype):
             return y.to_numpy(dtype=np.float64, na_value=np.nan, copy=False)
         counts = y.value_counts(dropna=True)
         if len(counts) > 2:
@@ -702,9 +691,7 @@ class CategoricalEncoder(_CategoricalBase):
         self.assignments_: Dict[str, str] = {}
         for column in self.columns_:
             cp = context.column_profile(column)
-            cardinality = (
-                cp.n_unique if cp is not None else int(X[column].nunique(dropna=True))
-            )
+            cardinality = cp.n_unique if cp is not None else int(X[column].nunique(dropna=True))
             if cp is not None and cp.semantic is SemanticType.ORDINAL:
                 self.assignments_[column] = "ordinal"
                 continue

--- a/src/edaprep/preprocessing/missing.py
+++ b/src/edaprep/preprocessing/missing.py
@@ -140,9 +140,7 @@ class MissingValueHandler(Transformer, ColumnTransformerMixin):
                 if strategy == "constant":
                     if self.fill_value is None:
                         override = context.config.get_column(column)
-                        value = (
-                            override.imputation_fill_value if override is not None else None
-                        )
+                        value = override.imputation_fill_value if override is not None else None
                         if value is None:
                             raise ConfigurationError(
                                 f"strategy='constant' for column {column!r} needs a fill "
@@ -179,9 +177,7 @@ class MissingValueHandler(Transformer, ColumnTransformerMixin):
                 "strategies": dict(self.strategies_),
             }
 
-    def _learn(
-        self, series: pd.Series, strategy: str, column: str, context: FitContext
-    ) -> Any:
+    def _learn(self, series: pd.Series, strategy: str, column: str, context: FitContext) -> Any:
         clean = series.dropna()
         if clean.empty:
             context.journal.warn(
@@ -358,6 +354,4 @@ class MissingIndicator(Transformer, ColumnTransformerMixin):
         return self._rebuild(X, {}, added)
 
     def _compute_feature_names_out(self) -> List[str]:
-        return list(self.feature_names_in_) + [
-            self.indicator_names_[c] for c in self.columns_
-        ]
+        return list(self.feature_names_in_) + [self.indicator_names_[c] for c in self.columns_]

--- a/src/edaprep/preprocessing/outliers.py
+++ b/src/edaprep/preprocessing/outliers.py
@@ -148,9 +148,7 @@ class ZScoreDetector(OutlierDetector):
 
     def __init__(self, threshold: float = 3.0, ddof: int = 0) -> None:
         if threshold <= 0:
-            raise ConfigurationError(
-                f"ZScoreDetector(threshold={threshold}) must be positive."
-            )
+            raise ConfigurationError(f"ZScoreDetector(threshold={threshold}) must be positive.")
         self.threshold = float(threshold)
         self.ddof = int(ddof)
 
@@ -275,9 +273,7 @@ def make_detector(method: str, thresholds: Thresholds, skewed: bool = False) -> 
     raise ConfigurationError.unknown_option("outlier_method", method, sorted(_DETECTORS))
 
 
-def detect_outliers(
-    series: pd.Series, method: str = "iqr", **kwargs
-) -> pd.Series:
+def detect_outliers(series: pd.Series, method: str = "iqr", **kwargs) -> pd.Series:
     """Convenience: a boolean Series flagging outliers in ``series``.
 
     Aligned to the input index; missing values are never flagged.  This is the
@@ -354,9 +350,9 @@ class OutlierHandler(Transformer, ColumnTransformerMixin):
             if cp is not None:
                 if cp.semantic is not SemanticType.NUMERIC:
                     continue
-            elif not pd.api.types.is_numeric_dtype(
+            elif not pd.api.types.is_numeric_dtype(X[name].dtype) or pd.api.types.is_bool_dtype(
                 X[name].dtype
-            ) or pd.api.types.is_bool_dtype(X[name].dtype):
+            ):
                 continue
             # Columns created mid-pipeline (missing indicators, one-hot columns,
             # calendar flags) have no profile entry, so the semantic check above cannot

--- a/src/edaprep/preprocessing/selection.py
+++ b/src/edaprep/preprocessing/selection.py
@@ -238,8 +238,7 @@ class DuplicateColumnFilter(_Dropper):
                 context.journal.warn(
                     "dropped_duplicate_columns",
                     f"{len(self.to_drop_)} duplicate column(s) removed, keeping the "
-                    f"first of each group: "
-                    + "; ".join("=".join(g) for g in self.groups_[:5]),
+                    f"first of each group: " + "; ".join("=".join(g) for g in self.groups_[:5]),
                     Severity.INFO,
                     tuple(self.to_drop_),
                     {"groups": [list(g) for g in self.groups_]},
@@ -350,7 +349,10 @@ class CorrelationFilter(_Dropper):
 
         if len(self.columns_) < 2 or len(X) < 3:
             context.journal.record(
-                self.stage, type(self).__name__, "correlation_filter", "fit",
+                self.stage,
+                type(self).__name__,
+                "correlation_filter",
+                "fit",
                 effect={"n_dropped": 0, "reason": "fewer than 2 numeric columns"},
             )
             return

--- a/src/edaprep/preprocessing/text.py
+++ b/src/edaprep/preprocessing/text.py
@@ -56,9 +56,7 @@ class TextColumnHandler(Transformer, ColumnTransformerMixin):
 
     stage = Stage.ENCODE
 
-    def __init__(
-        self, columns: Optional[Sequence[str]] = None, strategy: str = "drop"
-    ) -> None:
+    def __init__(self, columns: Optional[Sequence[str]] = None, strategy: str = "drop") -> None:
         super().__init__(columns)
         self.strategy = strategy
 

--- a/src/edaprep/preprocessing/transformations.py
+++ b/src/edaprep/preprocessing/transformations.py
@@ -207,9 +207,7 @@ class DistributionTransformer(Transformer, ColumnTransformerMixin):
                 column, method, "the column is constant in the training data"
             )
 
-    def _learn(
-        self, column: str, method: str, finite: np.ndarray, context: FitContext
-    ) -> None:
+    def _learn(self, column: str, method: str, finite: np.ndarray, context: FitContext) -> None:
         if method in ("log", "log1p", "sqrt"):
             self.params_[column] = {}
             return

--- a/src/edaprep/profiling/column_types.py
+++ b/src/edaprep/profiling/column_types.py
@@ -235,9 +235,7 @@ def infer_semantic_type(
         )
 
     # --- 2. dtypes that settle the question -------------------------------------
-    if pd.api.types.is_datetime64_any_dtype(dtype) or isinstance(
-        dtype, pd.DatetimeTZDtype
-    ):
+    if pd.api.types.is_datetime64_any_dtype(dtype) or isinstance(dtype, pd.DatetimeTZDtype):
         return TypeInference(
             SemanticType.DATETIME, confidence=1.0, reasons=("stored as a datetime dtype",)
         )
@@ -324,8 +322,7 @@ def infer_semantic_type(
                     confidence=min(conf, 0.95),
                     alternatives=(SemanticType.CATEGORICAL,),
                     reasons=(
-                        f"mean length {mean_len:.0f} chars, {mean_tokens:.1f} tokens "
-                        f"per value",
+                        f"mean length {mean_len:.0f} chars, {mean_tokens:.1f} tokens per value",
                     ),
                     extra={"mean_length": mean_len, "mean_tokens": mean_tokens},
                 )

--- a/src/edaprep/profiling/profiler.py
+++ b/src/edaprep/profiling/profiler.py
@@ -116,9 +116,7 @@ class ColumnProfile:
             "is_target": self.is_target,
             "modal_value": quality_mod._jsonable(self.modal_value),
             "modal_frequency": round(self.modal_frequency, 6),
-            "top_values": [
-                [quality_mod._jsonable(v), c] for v, c in self.top_values
-            ],
+            "top_values": [[quality_mod._jsonable(v), c] for v, c in self.top_values],
         }
         if self.numeric is not None:
             out["numeric"] = self.numeric.to_dict()
@@ -396,9 +394,7 @@ def _target_kind_is_categorical(target_kind: Optional[str]) -> bool:
     return target_kind == "classification"
 
 
-def _correlation_ratio_batch(
-    target: pd.Series, values: pd.DataFrame
-) -> Dict[str, float]:
+def _correlation_ratio_batch(target: pd.Series, values: pd.DataFrame) -> Dict[str, float]:
     """Eta for every numeric column against one categorical target, in k passes.
 
     The per-column :func:`_correlation_ratio` runs a pandas ``groupby`` per feature.
@@ -426,9 +422,7 @@ def _correlation_ratio_batch(
     if chunk < len(names):
         out: Dict[str, float] = {}
         for start in range(0, len(names), chunk):
-            out.update(
-                _correlation_ratio_batch(target, values.iloc[:, start : start + chunk])
-            )
+            out.update(_correlation_ratio_batch(target, values.iloc[:, start : start + chunk]))
         return out
 
     matrix = values.to_numpy(dtype=np.float64, na_value=np.nan, copy=False)
@@ -838,9 +832,7 @@ def _build_issues(
     issues: List[Issue] = []
 
     if n_rows == 0:
-        issues.append(
-            Issue("empty_dataset", Severity.ERROR, "The dataset has 0 rows.")
-        )
+        issues.append(Issue("empty_dataset", Severity.ERROR, "The dataset has 0 rows."))
 
     constants = [c for c in column_order if columns[c].is_constant]
     if constants:
@@ -865,11 +857,7 @@ def _build_issues(
                 f">={thresholds.near_constant_ratio:.0%} of rows): "
                 f"{_names(near_constants)}.",
                 tuple(near_constants),
-                {
-                    "columns": {
-                        c: round(columns[c].modal_frequency, 4) for c in near_constants
-                    }
-                },
+                {"columns": {c: round(columns[c].modal_frequency, 4) for c in near_constants}},
             )
         )
 
@@ -987,8 +975,7 @@ def _build_issues(
                 "correlated_missingness",
                 Severity.INFO,
                 f"{len(comissing)} column pair(s) go missing together, which usually "
-                f"means a shared cause: "
-                + ", ".join(f"{a}~{b} ({c:.2f})" for a, b, c in top),
+                f"means a shared cause: " + ", ".join(f"{a}~{b} ({c:.2f})" for a, b, c in top),
                 tuple({c for pair in comissing for c in pair[:2]}),
                 {"pairs": [[a, b, round(c, 4)] for a, b, c in comissing]},
             )

--- a/src/edaprep/profiling/statistics.py
+++ b/src/edaprep/profiling/statistics.py
@@ -60,6 +60,7 @@ __all__ = [
 #: the quartiles feed the IQR fence, and P5/P95 are reported for context.
 DEFAULT_QUANTILES: Tuple[float, ...] = (0.01, 0.05, 0.25, 0.50, 0.75, 0.95, 0.99)
 
+
 @dataclass(frozen=True)
 class NumericStats:
     """Moment and order statistics for a single numeric column."""
@@ -189,11 +190,7 @@ def _to_numeric_frame(frame: pd.DataFrame) -> pd.DataFrame:
     once here is what keeps the rest of the library dtype-agnostic.  Columns that are
     already float64 are passed through without a copy.
     """
-    needs_cast = [
-        name
-        for name in frame.columns
-        if frame[name].dtype != np.float64
-    ]
+    needs_cast = [name for name in frame.columns if frame[name].dtype != np.float64]
     if not needs_cast:
         return frame
     converted = {}
@@ -211,9 +208,7 @@ def _to_numeric_frame(frame: pd.DataFrame) -> pd.DataFrame:
                     name=str(name),
                 )
             except (TypeError, ValueError):
-                converted[str(name)] = pd.to_numeric(series, errors="coerce").astype(
-                    "float64"
-                )
+                converted[str(name)] = pd.to_numeric(series, errors="coerce").astype("float64")
     return pd.DataFrame(converted, index=frame.index, copy=False)
 
 
@@ -358,9 +353,7 @@ def _repair_small_magnitude(
     Columns whose spread really *is* rounding noise are handled separately by
     :func:`_denoise`, which runs afterwards and wins.
     """
-    at_risk = np.flatnonzero(
-        np.isfinite(std) & (std > 0.0) & (std**2 < _SMALL_MOMENT)
-    )
+    at_risk = np.flatnonzero(np.isfinite(std) & (std > 0.0) & (std**2 < _SMALL_MOMENT))
     if at_risk.size == 0:
         return skew, kurtosis
     skew = skew.copy()

--- a/src/edaprep/reporting/html.py
+++ b/src/edaprep/reporting/html.py
@@ -99,10 +99,7 @@ def render_html(report: "Report") -> str:
 
     if report.plan is not None and report.plan.decisions:
         add("<h2>Decisions</h2><div class='scroll'><table>")
-        add(
-            "<tr><th>column</th><th>stage</th><th>action</th>"
-            "<th>why</th><th>source</th></tr>"
-        )
+        add("<tr><th>column</th><th>stage</th><th>action</th><th>why</th><th>source</th></tr>")
         for d in sorted(report.plan.decisions, key=lambda d: (d.column, d.stage.order)):
             source = (
                 "<span class='override'>user override</span>"

--- a/src/edaprep/reporting/report.py
+++ b/src/edaprep/reporting/report.py
@@ -100,9 +100,7 @@ class Report:
 
         The audit hand-written pipelines need and rarely have.
         """
-        target_users = [
-            e for e in self.entries if "target_encode" in e.action
-        ]
+        target_users = [e for e in self.entries if "target_encode" in e.action]
         suspicious: List[str] = []
         if self.profile is not None:
             for issue in self.profile.issues:
@@ -110,9 +108,7 @@ class Report:
                     suspicious.extend(issue.columns)
         return {
             "target": self.plan.target if self.plan else None,
-            "transformers_using_target": sorted(
-                {e.transformer for e in target_users}
-            ),
+            "transformers_using_target": sorted({e.transformer for e in target_users}),
             "cross_fitted": any(e.action == "target_encode_oof" for e in target_users),
             "columns_suspected_of_leakage": suspicious,
             "statistics_learned_at_fit_only": True,
@@ -176,8 +172,7 @@ class Report:
             )
             if p.n_duplicate_rows:
                 lines.append(
-                    f"  {p.n_duplicate_rows:,} duplicate rows "
-                    f"({p.duplicate_row_fraction:.2%})"
+                    f"  {p.n_duplicate_rows:,} duplicate rows ({p.duplicate_row_fraction:.2%})"
                 )
             if p.target:
                 extra = f", {p.target_classes} classes" if p.target_classes else ""
@@ -187,8 +182,7 @@ class Report:
 
         lines.append("")
         lines.append(
-            f"Features: {len(self.feature_names_in)} in -> "
-            f"{len(self.feature_names_out)} out"
+            f"Features: {len(self.feature_names_in)} in -> {len(self.feature_names_out)} out"
         )
 
         dropped = self.dropped_columns
@@ -268,9 +262,7 @@ class Report:
 
     def _render_stage(self, stage: Stage, max_rows: int) -> List[str]:
         """Per-column lines combining the decision with its measured effect."""
-        decisions = (
-            [d for d in self.plan.decisions if d.stage is stage] if self.plan else []
-        )
+        decisions = [d for d in self.plan.decisions if d.stage is stage] if self.plan else []
         entries = [e for e in self.for_stage(stage) if e.phase == "transform"]
 
         effects: Dict[str, str] = {}
@@ -294,9 +286,7 @@ class Report:
                 mark = "*" if decision.is_override else " "
                 effect = effects.get(decision.column, "")
                 suffix = f"  [{effect}]" if effect else ""
-                lines.append(
-                    f" {mark} {decision.column:<26.26} -> {decision.action}{suffix}"
-                )
+                lines.append(f" {mark} {decision.column:<26.26} -> {decision.action}{suffix}")
             if len(decisions) > max_rows:
                 lines.append(f"   ... {len(decisions) - max_rows} more")
             return lines

--- a/src/edaprep/visualization/plots.py
+++ b/src/edaprep/visualization/plots.py
@@ -130,9 +130,7 @@ def histogram(
     return ax
 
 
-def boxplot(
-    data: pd.DataFrame, columns: Sequence[str], ax: "Optional[Axes]" = None
-) -> "Axes":
+def boxplot(data: pd.DataFrame, columns: Sequence[str], ax: "Optional[Axes]" = None) -> "Axes":
     """Box plots for several columns side by side."""
     series = [pd.to_numeric(data[c], errors="coerce").dropna().to_numpy() for c in columns]
     ax = _axes(ax, figsize=(max(6, 1.2 * len(columns)), 5))
@@ -197,9 +195,7 @@ def category_bar(
     return ax
 
 
-def target_distribution(
-    data: pd.DataFrame, target: str, ax: "Optional[Axes]" = None
-) -> "Axes":
+def target_distribution(data: pd.DataFrame, target: str, ax: "Optional[Axes]" = None) -> "Axes":
     """Target distribution: a bar chart for classification, a histogram otherwise."""
     series = data[target].dropna()
     ax = _axes(ax)
@@ -288,9 +284,9 @@ def plot_profile(
         if profile.columns[c].semantic is SemanticType.NUMERIC and c != target
     ]
     numeric.sort(
-        key=lambda c: abs(profile.columns[c].skew)
-        if np.isfinite(profile.columns[c].skew)
-        else 0.0,
+        key=lambda c: (
+            abs(profile.columns[c].skew) if np.isfinite(profile.columns[c].skew) else 0.0
+        ),
         reverse=True,
     )
     numeric = numeric[:max_numeric]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,7 @@ def messy_frame() -> pd.DataFrame:
     balance = gen.normal(0, 500, n)
     balance[gen.choice(n, 200, replace=False)] = 0.0  # zero-heavy
 
-    city = gen.choice(
-        [f"city_{i:03d}" for i in range(180)], n
-    )  # high cardinality categorical
+    city = gen.choice([f"city_{i:03d}" for i in range(180)], n)  # high cardinality categorical
 
     workclass = gen.choice(["Private", "Gov", "SelfEmp", "?"], n, p=[0.6, 0.2, 0.15, 0.05])
     occupation = np.where(workclass == "?", "?", gen.choice(["Tech", "Sales", "Admin"], n))

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -80,9 +80,7 @@ def test_transform_output_is_independent_of_batching(split_frame) -> None:
     pipe.fit(train)
 
     whole = pipe.transform(test)
-    row_by_row = pd.concat(
-        [pipe.transform(test.iloc[[i]]) for i in range(len(test))], axis=0
-    )
+    row_by_row = pd.concat([pipe.transform(test.iloc[[i]]) for i in range(len(test))], axis=0)
     pd.testing.assert_frame_equal(whole, row_by_row, check_exact=False, rtol=1e-12)
 
 
@@ -139,9 +137,7 @@ def test_imputer_uses_train_median_only(split_frame) -> None:
     test.loc[test.index[:20], "num"] = np.nan
 
     context = _context(train)
-    handler = MissingValueHandler(["num"], strategy="median").fit(
-        train, train["y"], context
-    )
+    handler = MissingValueHandler(["num"], strategy="median").fit(train, train["y"], context)
     train_median = train["num"].median()
     assert handler.fill_values_["num"] == pytest.approx(train_median)
 
@@ -205,9 +201,7 @@ def test_target_encoding_is_cross_fitted() -> None:
     gen = np.random.default_rng(5)
     n = 600
     # One category per 2 rows: the pathological case for target encoding.
-    frame = pd.DataFrame(
-        {"c": [f"lvl_{i // 2}" for i in range(n)], "y": gen.integers(0, 2, n)}
-    )
+    frame = pd.DataFrame({"c": [f"lvl_{i // 2}" for i in range(n)], "y": gen.integers(0, 2, n)})
     context = _context(frame)
 
     encoder = TargetEncoder(["c"])
@@ -226,9 +220,7 @@ def test_target_encoding_is_cross_fitted() -> None:
 def test_target_encoder_fit_transform_differs_from_fit_then_transform() -> None:
     """The one place the two legitimately differ, and it must be the declared one."""
     gen = np.random.default_rng(6)
-    frame = pd.DataFrame(
-        {"c": gen.choice(list("abcdefgh"), 300), "y": gen.integers(0, 2, 300)}
-    )
+    frame = pd.DataFrame({"c": gen.choice(list("abcdefgh"), 300), "y": gen.integers(0, 2, 300)})
     context = _context(frame)
 
     a = TargetEncoder(["c"]).fit_transform(frame, frame["y"], context)["c"]
@@ -239,9 +231,7 @@ def test_target_encoder_fit_transform_differs_from_fit_then_transform() -> None:
 def test_target_encoder_transform_is_not_cross_fitted() -> None:
     """At transform time the full-train mapping is correct and must be used."""
     gen = np.random.default_rng(7)
-    frame = pd.DataFrame(
-        {"c": gen.choice(list("abc"), 300), "y": gen.integers(0, 2, 300)}
-    )
+    frame = pd.DataFrame({"c": gen.choice(list("abc"), 300), "y": gen.integers(0, 2, 300)})
     context = _context(frame)
     encoder = TargetEncoder(["c"]).fit(frame, frame["y"], context)
     out = encoder.transform(pd.DataFrame({"c": ["a", "b", "c"]}), context)
@@ -340,8 +330,21 @@ def test_transform_methods_compute_no_statistics() -> None:
     # Names that aggregate over data.  A call to any of these inside _transform means
     # the output for one row depends on the other rows in the same batch.
     forbidden = {
-        "mean", "median", "quantile", "std", "var", "mode", "value_counts",
-        "nunique", "corr", "cov", "skew", "kurt", "factorize", "unique", "rank",
+        "mean",
+        "median",
+        "quantile",
+        "std",
+        "var",
+        "mode",
+        "value_counts",
+        "nunique",
+        "corr",
+        "cov",
+        "skew",
+        "kurt",
+        "factorize",
+        "unique",
+        "rank",
     }
     # (transformer, attribute) pairs that are aggregations over something other than
     # the incoming data, with the reason recorded.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -152,9 +152,7 @@ def test_model_family_changes_the_plan(frame) -> None:
     assert any(s.stage is Stage.SCALE for s in linear.plan_)
 
     tree_enc = {d.column: d.action for d in tree.plan_.decisions if d.stage is Stage.ENCODE}
-    linear_enc = {
-        d.column: d.action for d in linear.plan_.decisions if d.stage is Stage.ENCODE
-    }
+    linear_enc = {d.column: d.action for d in linear.plan_.decisions if d.stage is Stage.ENCODE}
     assert tree_enc["city"] == "encode_ordinal"
     assert linear_enc["city"] == "encode_target"
 
@@ -355,9 +353,7 @@ def test_custom_rule_can_pre_empt_a_builtin(frame) -> None:
     ).fit(frame)
     # The custom rule only claims NUMERIC columns; ordinal and binary ones fall
     # through to the built-in, which is exactly how priority-ordered rules should work.
-    scale = {
-        d.column: d.action for d in pipe.plan_.decisions if d.stage is Stage.SCALE
-    }
+    scale = {d.column: d.action for d in pipe.plan_.decisions if d.stage is Stage.SCALE}
     assert scale["income"] == "scale_maxabs"
     assert scale["age"] == "scale_maxabs"
     assert scale["grade"] == "scale_standard"
@@ -480,9 +476,7 @@ def test_duplicate_rows_are_reported_not_removed() -> None:
 
 def test_unseen_categories_at_transform_time() -> None:
     gen = np.random.default_rng(5)
-    train = pd.DataFrame(
-        {"c": gen.choice(list("abc"), 300), "y": gen.integers(0, 2, 300)}
-    )
+    train = pd.DataFrame({"c": gen.choice(list("abc"), 300), "y": gen.integers(0, 2, 300)})
     test = pd.DataFrame({"c": ["a", "z", "q"], "y": [0, 1, 0]})
     pipe = AutoPipeline(target="y", model_family="linear", random_state=0).fit(train)
     out = pipe.transform(test)
@@ -620,11 +614,11 @@ def test_cast_introduced_nan_is_imputed() -> None:
     gen = np.random.default_rng(7)
     n = 300
     charges = [f"{v:.2f}" for v in gen.uniform(20, 8000, size=n)]
-    for i in range(0, 30, 3):          # 10 blanks, as strings
+    for i in range(0, 30, 3):  # 10 blanks, as strings
         charges[i] = " "
     frame = pd.DataFrame(
         {
-            "total_charges": charges,          # object dtype purely because of the blanks
+            "total_charges": charges,  # object dtype purely because of the blanks
             "tenure": gen.integers(1, 72, size=n),
             "churn": gen.integers(0, 2, size=n),
         }
@@ -656,13 +650,12 @@ def test_cast_introduced_nan_is_imputed() -> None:
 def test_cast_introduced_nan_imputed_on_unseen_test_rows() -> None:
     """The fitted statistic must carry to transform, not be recomputed per batch."""
     gen = np.random.default_rng(11)
+
     def make(n: int, blanks: int) -> pd.DataFrame:
         vals = [f"{v:.2f}" for v in gen.uniform(10, 500, size=n)]
         for i in range(blanks):
             vals[i] = ""
-        return pd.DataFrame(
-            {"amount": vals, "y": gen.integers(0, 2, size=n)}
-        )
+        return pd.DataFrame({"amount": vals, "y": gen.integers(0, 2, size=n)})
 
     train, test = make(200, 8), make(80, 5)
     pipe = AutoPipeline(target="y", model_family="linear", random_state=0).fit(train)
@@ -696,11 +689,11 @@ def test_placeholder_strings_get_a_missing_indicator() -> None:
     gen = np.random.default_rng(21)
     n = 300
     amounts = [f"{v:.2f}" for v in gen.uniform(20, 8000, size=n)]
-    for i in range(0, 72, 3):          # 24 blanks (8%), as strings
+    for i in range(0, 72, 3):  # 24 blanks (8%), as strings
         amounts[i] = ""
     frame = pd.DataFrame(
         {
-            "amount": amounts,          # object dtype purely because of the blanks
+            "amount": amounts,  # object dtype purely because of the blanks
             "y": gen.integers(0, 2, size=n),
         }
     )
@@ -736,7 +729,7 @@ def test_placeholder_heavy_column_is_dropped_rather_than_imputed() -> None:
     gen = np.random.default_rng(23)
     n = 300
     amounts = [f"{v:.2f}" for v in gen.uniform(20, 8000, size=n)]
-    for i in range(210):               # 210 blanks (70%), as strings
+    for i in range(210):  # 210 blanks (70%), as strings
         amounts[i] = ""
     # Two distinct non-null values must survive, otherwise drop_constant could claim
     # the column first and this test would be measuring the wrong rule.
@@ -770,7 +763,7 @@ def test_placeholder_heavy_column_with_fewer_than_60pct_is_not_dropped() -> None
     gen = np.random.default_rng(31)
     n = 300
     amounts = [f"{v:.2f}" for v in gen.uniform(20, 8000, size=n)]
-    for i in range(90):                # 90 blanks (30%), as strings
+    for i in range(90):  # 90 blanks (30%), as strings
         amounts[i] = ""
     frame = pd.DataFrame(
         {
@@ -790,10 +783,8 @@ def test_column_with_real_nan_still_gets_a_missing_indicator() -> None:
     gen = np.random.default_rng(29)
     n = 300
     values = gen.uniform(20, 8000, size=n).astype(float)
-    values[gen.choice(n, 24, replace=False)] = np.nan   # 8% real missing
-    frame = pd.DataFrame(
-        {"amount": values, "y": gen.integers(0, 2, size=n)}
-    )
+    values[gen.choice(n, 24, replace=False)] = np.nan  # 8% real missing
+    frame = pd.DataFrame({"amount": values, "y": gen.integers(0, 2, size=n)})
     pipe = AutoPipeline(target="y", model_family="linear", random_state=0)
     out = pipe.fit_transform(frame)
 
@@ -813,7 +804,7 @@ def test_from_dict_tolerates_settings_this_version_removed() -> None:
     saved_by_an_older_version = {
         "random_state": 42,
         "sample_size": None,
-        "n_jobs": 1,          # retired in 0.2.0
+        "n_jobs": 1,  # retired in 0.2.0
         "verbose": False,
     }
     with pytest.warns(UserWarning, match="n_jobs"):
@@ -831,7 +822,7 @@ def test_from_dict_round_trip_is_warning_free() -> None:
     original.column("age").imputation = "median"
 
     with _warnings.catch_warnings():
-        _warnings.simplefilter("error")          # any warning fails the test
+        _warnings.simplefilter("error")  # any warning fails the test
         restored = Config.from_dict(json.loads(json.dumps(original.to_dict())))
 
     assert restored.random_state == 7

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -70,9 +70,7 @@ def test_scalar_helpers_match_scipy() -> None:
     gen = np.random.default_rng(1)
     values = gen.lognormal(0, 1, 400)
     assert skewness(values) == pytest.approx(scipy_stats.skew(values, bias=False), rel=1e-9)
-    assert kurtosis(values) == pytest.approx(
-        scipy_stats.kurtosis(values, bias=False), rel=1e-9
-    )
+    assert kurtosis(values) == pytest.approx(scipy_stats.kurtosis(values, bias=False), rel=1e-9)
     assert median_abs_deviation(values) == pytest.approx(
         scipy_stats.median_abs_deviation(values, scale=1.0), rel=1e-12
     )

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -260,9 +260,7 @@ def test_degenerate_fence_downgrades_to_report() -> None:
 def test_outlier_remove_does_not_drop_rows_during_transform() -> None:
     frame = pd.DataFrame({"x": np.concatenate([np.arange(100.0), [10_000.0]])})
     context = ctx(frame)
-    handler = OutlierHandler(["x"], method="iqr", strategy="remove").fit(
-        frame, None, context
-    )
+    handler = OutlierHandler(["x"], method="iqr", strategy="remove").fit(frame, None, context)
     assert len(handler.transform(frame, context)) == len(frame)
     assert handler.rows_to_remove(frame).sum() == 1
 
@@ -278,9 +276,7 @@ def test_imputer_matches_sklearn(strategy) -> None:
     values = gen.normal(size=200)
     values[::7] = np.nan
     frame = pd.DataFrame({"x": values})
-    ours = MissingValueHandler(["x"], strategy=strategy).fit_transform(
-        frame, None, ctx(frame)
-    )
+    ours = MissingValueHandler(["x"], strategy=strategy).fit_transform(frame, None, ctx(frame))
     theirs = SimpleImputer(strategy=strategy).fit_transform(frame)
     np.testing.assert_allclose(ours.to_numpy(), theirs)
 
@@ -292,9 +288,7 @@ def test_mode_imputation_matches_sklearn() -> None:
     # object column (it sorts the values). edaprep handles both, which the next test
     # pins down; here the point is only that the chosen mode agrees.
     frame = pd.DataFrame({"c": ["a", "a", "b", np.nan, np.nan, "c"]})
-    ours = MissingValueHandler(["c"], strategy="mode").fit_transform(
-        frame, None, ctx(frame)
-    )
+    ours = MissingValueHandler(["c"], strategy="mode").fit_transform(frame, None, ctx(frame))
     theirs = SimpleImputer(strategy="most_frequent").fit_transform(frame)
     assert ours["c"].tolist() == [v[0] for v in theirs]
 
@@ -340,9 +334,7 @@ def test_mostly_missing_column_is_imputed_but_reported() -> None:
     frame = pd.DataFrame({"x": [1.0] + [np.nan] * 99})
     context = ctx(frame)
     MissingValueHandler(["x"], strategy="median").fit(frame, None, context)
-    assert any(
-        w.code == "imputed_mostly_missing_column" for w in context.journal.warnings
-    )
+    assert any(w.code == "imputed_mostly_missing_column" for w in context.journal.warnings)
 
 
 def test_constant_imputation_without_a_value_is_an_error() -> None:
@@ -431,9 +423,7 @@ def test_frequency_encoder_and_unseen_categories() -> None:
 
 def test_rare_category_grouping() -> None:
     frame = pd.DataFrame({"c": ["common"] * 990 + [f"rare{i}" for i in range(10)]})
-    out = RareCategoryGrouper(["c"], threshold=0.01).fit_transform(
-        frame, None, ctx(frame)
-    )
+    out = RareCategoryGrouper(["c"], threshold=0.01).fit_transform(frame, None, ctx(frame))
     assert set(out["c"].unique()) == {"common", "__rare__"}
     assert (out["c"] == "__rare__").sum() == 10
 
@@ -470,9 +460,9 @@ def test_yeojohnson_matches_sklearn() -> None:
 
     gen = np.random.default_rng(11)
     frame = pd.DataFrame({"x": gen.lognormal(0, 1, 300)})
-    ours = DistributionTransformer(
-        ["x"], method="yeojohnson", standardize=True
-    ).fit_transform(frame, None, ctx(frame))
+    ours = DistributionTransformer(["x"], method="yeojohnson", standardize=True).fit_transform(
+        frame, None, ctx(frame)
+    )
     theirs = PowerTransformer(method="yeo-johnson", standardize=True).fit_transform(frame)
     np.testing.assert_allclose(ours.to_numpy(), theirs, rtol=1e-6, atol=1e-8)
 
@@ -539,17 +529,13 @@ def test_domain_violation_at_transform_time_is_reported() -> None:
     transformer = DistributionTransformer(["x"], method="log").fit(train, None, context)
     out = transformer.transform(pd.DataFrame({"x": [-5.0, 10.0]}), context)
     assert pd.isna(out["x"].iloc[0])
-    assert any(
-        w.code == "transform_domain_violation" for w in context.journal.warnings
-    )
+    assert any(w.code == "transform_domain_violation" for w in context.journal.warnings)
 
 
 def test_quantile_transform_clamps_unseen_extremes() -> None:
     train = pd.DataFrame({"x": np.arange(100.0)})
     context = ctx(train)
-    transformer = DistributionTransformer(["x"], method="quantile").fit(
-        train, None, context
-    )
+    transformer = DistributionTransformer(["x"], method="quantile").fit(train, None, context)
     out = transformer.transform(pd.DataFrame({"x": [-1000.0, 1000.0]}), context)
     assert out["x"].tolist() == [0.0, 1.0]
 
@@ -618,27 +604,21 @@ def test_integer_downcast_preserves_values() -> None:
 def test_float_downcast_is_refused_when_values_would_collide() -> None:
     """Distinct rows must not become identical to the model."""
     frame = pd.DataFrame({"f": [1.000000001, 1.000000002, 2.0]})
-    out = DataTypeInference(["f"], downcast_floats=True).fit_transform(
-        frame, None, ctx(frame)
-    )
+    out = DataTypeInference(["f"], downcast_floats=True).fit_transform(frame, None, ctx(frame))
     assert out["f"].dtype == np.float64
     assert out["f"].nunique() == 3
 
 
 def test_float_downcast_is_refused_when_out_of_range() -> None:
     frame = pd.DataFrame({"f": [1e39, 2e39, 3.0]})
-    out = DataTypeInference(["f"], downcast_floats=True).fit_transform(
-        frame, None, ctx(frame)
-    )
+    out = DataTypeInference(["f"], downcast_floats=True).fit_transform(frame, None, ctx(frame))
     assert out["f"].dtype == np.float64  # float32 would overflow to inf
 
 
 def test_float_downcast_applies_when_safe() -> None:
     frame = pd.DataFrame({"f": np.arange(100.0)})
     context = ctx(frame)
-    out = DataTypeInference(["f"], downcast_floats=True).fit_transform(
-        frame, None, context
-    )
+    out = DataTypeInference(["f"], downcast_floats=True).fit_transform(frame, None, context)
     assert out["f"].dtype == np.float32
     assert any(w.code == "float_downcast_is_lossy" for w in context.journal.warnings)
 
@@ -674,9 +654,7 @@ def test_variance_filter_warns_about_scale_dependence() -> None:
     frame = pd.DataFrame({"small": np.arange(100) * 1e-6, "big": np.arange(100.0)})
     context = ctx(frame)
     VarianceFilter(threshold=1e-6).fit(frame, None, context)
-    assert any(
-        w.code == "variance_filter_is_scale_dependent" for w in context.journal.warnings
-    )
+    assert any(w.code == "variance_filter_is_scale_dependent" for w in context.journal.warnings)
 
 
 def test_correlation_filter_is_order_independent() -> None:
@@ -693,13 +671,9 @@ def test_correlation_filter_is_order_independent() -> None:
     )
     forward = CorrelationFilter(threshold=0.95).fit(frame, None, ctx(frame))
     reversed_frame = frame[["d", "c", "b", "a"]]
-    backward = CorrelationFilter(threshold=0.95).fit(
-        reversed_frame, None, ctx(reversed_frame)
-    )
+    backward = CorrelationFilter(threshold=0.95).fit(reversed_frame, None, ctx(reversed_frame))
     # The same group is identified either way; only the representative may differ.
-    assert {frozenset(g) for g in forward.groups_} == {
-        frozenset(g) for g in backward.groups_
-    }
+    assert {frozenset(g) for g in forward.groups_} == {frozenset(g) for g in backward.groups_}
     assert len(forward.to_drop_) == len(backward.to_drop_) == 2
 
 
@@ -810,9 +784,7 @@ def test_text_length_features() -> None:
     frame = pd.DataFrame(
         {"t": [f"A long free text remark number {i} about the service." for i in range(100)]}
     )
-    out = TextColumnHandler(strategy="length_features").fit_transform(
-        frame, None, ctx(frame)
-    )
+    out = TextColumnHandler(strategy="length_features").fit_transform(frame, None, ctx(frame))
     assert "t__length" in out.columns and "t__n_words" in out.columns
 
 


### PR DESCRIPTION
Closes #4

Two commits:

1. `style: run ruff format on src tests benchmarks examples` — 33 files reformatted, formatting only. I reviewed the diff: no docstrings or intentionally aligned comments were mangled; the changes are standard line-wrapping / spacing / comment alignment.
2. `ci: enforce ruff format check` — drops the `|| true` from the format check and widens the paths to `src/ tests/ benchmarks/ examples/`, matching the formatting commit.