### PR TITLE
ci: ignore the formatting commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,16 @@
+# Commits that changed formatting only, never behaviour.
+#
+# git blame skips these with:
+#     git blame --ignore-revs-file .git-blame-ignore-revs <file>
+#
+# or permanently, once per clone:
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# GitHub's blame view honours this file automatically.
+#
+# Only add a commit here if it is provably behaviour-preserving. For the one
+# below that meant parsing every changed .py file before and after and comparing
+# the ASTs: 33 of 33 identical.
+
+# Enforce ruff format in CI (#25) -- formatted 34 files, no semantic change.
+4b6bedb17c1fdc504a1d301f887536d47f034829


### PR DESCRIPTION
Follow-up to #25, as promised in its review.

Formatting 34 files to enable `ruff format --check` was correct — much better paid at 34 files than later at 200. The cost is that `git blame` now attributes every touched line to the reformat instead of to whoever last changed it for a real reason.

`.git-blame-ignore-revs` removes that cost. [GitHub's blame view honours it automatically](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view), and locally it is one config line, documented at the top of the file.

The file states the bar for adding to it: **provably** behaviour-preserving, not merely intended to be. For #25 that meant parsing every changed `.py` on both sides and comparing ASTs — 33 of 33 identical.