### PR TITLE
docs: state the bar for adding a third-party service

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,22 @@ pytest -k "outlier"                     # by keyword
 
 ---
 
+## Third-party services
+
+The answer is usually no, and the bar is: **what happens when it fails?**
+
+Coverage reporting is the worked example (#5, #21). `codecov-action` needed a token
+the repo did not have and failed *silently* — CI stayed green, the badge would have
+read `unknown` indefinitely, and nobody would have been told. That is the same
+accepted-and-never-read shape as `Config.n_jobs`, which #11 removed.
+
+Coverage now goes to the GitHub job summary via `coverage report --format=markdown`,
+which is built into coverage.py. No token, no account, nothing to break, and it
+sorts worst-first so the output is worth reading rather than a single number.
+
+If you want to add a service, say in the PR what the failure mode is and how anyone
+would notice. "It silently stops working and CI still passes" is a rejection.
+
 ## Performance claims need a benchmark
 
 `docs/performance.md` §5 sets the method: minimum of N runs, candidates interleaved,


### PR DESCRIPTION
Prompted by #21, where `codecov-action` failed silently: CI green, three `Token required` errors buried in a passing job's log, and a badge that would have read `unknown` indefinitely.

That is the same shape as `Config.n_jobs` — accepted, never read, nobody told — which #11 removed. Worth writing down while the example is fresh.

The rule is not "no services". It is: **say what the failure mode is and how anyone would notice**. "It silently stops working and CI still passes" is a rejection.

Also records what replaced it, so the next person does not re-propose Codecov: `coverage report --format=markdown --sort=cover` is built into coverage.py, needs no token, and sorts worst-first so the output is worth reading.