### PR TITLE
fix: implement binary (base-N) categorical encoding

### DIFF
--- a/src/edaprep/preprocessing/__init__.py
+++ b/src/edaprep/preprocessing/__init__.py
@@ -8,6 +8,7 @@ from .casting import DataTypeInference
 from .datetime_features import DateTimeExpander
 from .duplicates import DuplicateRowHandler, duplicate_report
 from .encoding import (
+    BinaryEncoder,
     CategoricalEncoder,
     FrequencyEncoder,
     OneHotEncoder,
@@ -51,6 +52,7 @@ __all__ = [
     "detect_outliers",
     "CategoricalEncoder",
     "OneHotEncoder",
+    "BinaryEncoder",
     "OrdinalEncoder",
     "FrequencyEncoder",
     "TargetEncoder",

--- a/src/edaprep/preprocessing/encoding.py
+++ b/src/edaprep/preprocessing/encoding.py
@@ -33,6 +33,7 @@ from ..types import CATEGORICAL_LIKE, ModelFamily, SemanticType, Severity, Stage
 __all__ = [
     "RareCategoryGrouper",
     "OneHotEncoder",
+    "BinaryEncoder",
     "OrdinalEncoder",
     "FrequencyEncoder",
     "TargetEncoder",
@@ -307,6 +308,100 @@ class OneHotEncoder(_CategoricalBase):
                     added[name] = pd.Series(
                         (codes == code).astype(self.dtype), index=X.index, name=name
                     )
+
+            if unknown_counts:
+                context.journal.warn(
+                    "unseen_categories",
+                    f"{sum(unknown_counts.values())} value(s) across "
+                    f"{len(unknown_counts)} column(s) were not present at fit time and "
+                    f"were encoded as all-zero indicators: "
+                    f"{', '.join(sorted(unknown_counts))}.",
+                    Severity.INFO,
+                    tuple(unknown_counts),
+                    unknown_counts,
+                )
+
+            timer.columns = list(self.categories_)
+            timer.effect = {
+                "n_output_columns": len(added),
+                "n_unknown_values": unknown_counts,
+            }
+
+        remaining = {str(c): X[c] for c in X.columns if str(c) not in self.categories_}
+        return pd.DataFrame({**remaining, **added}, index=X.index, copy=False)
+
+    def _compute_feature_names_out(self) -> List[str]:
+        out = [c for c in self.feature_names_in_ if c not in self.categories_]
+        for column in self.categories_:
+            out.extend(self.output_names_[column])
+        return out
+
+
+class BinaryEncoder(_CategoricalBase):
+    """Expand each category into ``ceil(log2(n))`` binary indicator columns.
+
+    A middle ground between one-hot (``n`` columns) and ordinal (one column with a
+    false ordering).  Unseen categories at transform time are encoded as all-zero,
+    consistent with :class:`OneHotEncoder`.
+    """
+
+    stage = Stage.ENCODE
+
+    def __init__(
+        self,
+        columns: Optional[Sequence[str]] = None,
+        dtype: str = "int8",
+    ) -> None:
+        super().__init__(columns)
+        self.dtype = dtype
+
+    def _fit(self, X: pd.DataFrame, y: Optional[pd.Series], context: FitContext) -> None:
+        self.categories_: Dict[str, List[Any]] = {}
+        self.mappings_: Dict[str, Dict[Any, int]] = {}
+        self.n_bits_: Dict[str, int] = {}
+        self.output_names_: Dict[str, List[str]] = {}
+
+        with context.journal.timer(self.stage, type(self).__name__, "fit", "fit") as timer:
+            total = 0
+            for column in self.columns_:
+                series = self._as_object(X[column])
+                categories = sorted(series.dropna().unique(), key=_sort_key)
+                self.categories_[column] = categories
+                self.mappings_[column] = {c: i for i, c in enumerate(categories)}
+                n_bits = int(np.ceil(np.log2(max(len(categories), 1))))
+                self.n_bits_[column] = n_bits
+                self.output_names_[column] = [f"{column}__bin{i}" for i in range(n_bits)]
+                total += n_bits
+
+            timer.columns = list(self.columns_)
+            timer.effect = {"n_output_columns": total}
+
+    def _transform(self, X: pd.DataFrame, context: FitContext) -> pd.DataFrame:
+        added: Dict[str, pd.Series] = {}
+        unknown_counts: Dict[str, int] = {}
+
+        with context.journal.timer(
+            self.stage, type(self).__name__, "binary", "transform"
+        ) as timer:
+            for column in self.columns_:
+                if column not in X.columns:
+                    continue
+                series = self._as_object(X[column])
+                mapping = self.mappings_[column]
+                integer_codes = series.map(mapping)
+                unknown = series.notna() & integer_codes.isna()
+                n_unknown = int(unknown.sum())
+                if n_unknown:
+                    unknown_counts[column] = n_unknown
+
+                n_bits = self.n_bits_[column]
+                known = integer_codes.notna()
+                codes_int = integer_codes[known].to_numpy(dtype=np.int64)
+                for bit, name in enumerate(self.output_names_[column]):
+                    values = np.zeros(len(X), dtype=self.dtype)
+                    if known.any():
+                        values[known.to_numpy()] = ((codes_int >> bit) & 1).astype(self.dtype)
+                    added[name] = pd.Series(values, index=X.index, name=name)
 
             if unknown_counts:
                 context.journal.warn(
@@ -734,13 +829,9 @@ class CategoricalEncoder(_CategoricalBase):
         if strategy == "target":
             return TargetEncoder(cols)
         if strategy == "binary":
-            raise ConfigurationError(
-                "encoding='binary' is not implemented in this version. Use 'frequency' "
-                "or 'target' for high-cardinality columns; both produce a single "
-                "column and are better understood."
-            )
+            return BinaryEncoder(cols)
         raise ConfigurationError.unknown_option(
-            "encoding", strategy, ["onehot", "ordinal", "frequency", "count", "target"]
+            "encoding", strategy, ["onehot", "ordinal", "frequency", "count", "target", "binary"]
         )
 
     def _fit_transform(
@@ -774,12 +865,17 @@ class CategoricalEncoder(_CategoricalBase):
         return X[keep]
 
     def _compute_feature_names_out(self) -> List[str]:
-        # Must match _transform exactly.  One-hot appends its indicator columns at the
-        # end rather than expanding in place (expanding in place would mean rebuilding
+        # Must match _transform exactly.  One-hot and binary append indicator columns at
+        # the end rather than expanding in place (expanding in place would mean rebuilding
         # the frame around each encoded column), so the names have to be appended too.
         # Ordinal, frequency and target encoding all replace their column in position.
         onehot = self.encoders_.get("onehot")
-        encoded_away = set(getattr(onehot, "categories_", {})) if onehot else set()
+        binary = self.encoders_.get("binary")
+        encoded_away = set()
+        if onehot is not None:
+            encoded_away.update(onehot.categories_)  # type: ignore[attr-defined]
+        if binary is not None:
+            encoded_away.update(binary.categories_)  # type: ignore[attr-defined]
         names = [
             c
             for c in self.feature_names_in_
@@ -788,4 +884,7 @@ class CategoricalEncoder(_CategoricalBase):
         if onehot is not None:
             for column in onehot.categories_:  # type: ignore[attr-defined]
                 names.extend(onehot.output_names_[column])  # type: ignore[attr-defined]
+        if binary is not None:
+            for column in binary.categories_:  # type: ignore[attr-defined]
+                names.extend(binary.output_names_[column])  # type: ignore[attr-defined]
         return names

--- a/src/edaprep/preprocessing/encoding.py
+++ b/src/edaprep/preprocessing/encoding.py
@@ -394,7 +394,6 @@ class BinaryEncoder(_CategoricalBase):
                 if n_unknown:
                     unknown_counts[column] = n_unknown
 
-                n_bits = self.n_bits_[column]
                 known = integer_codes.notna()
                 codes_int = integer_codes[known].to_numpy(dtype=np.int64)
                 for bit, name in enumerate(self.output_names_[column]):
@@ -831,7 +830,9 @@ class CategoricalEncoder(_CategoricalBase):
         if strategy == "binary":
             return BinaryEncoder(cols)
         raise ConfigurationError.unknown_option(
-            "encoding", strategy, ["onehot", "ordinal", "frequency", "count", "target", "binary"]
+            "encoding",
+            strategy,
+            ["onehot", "ordinal", "frequency", "count", "target", "binary"],
         )
 
     def _fit_transform(

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -15,6 +15,7 @@ from edaprep.exceptions import (
     TransformationError,
 )
 from edaprep.preprocessing import (
+    BinaryEncoder,
     CategoricalEncoder,
     ColumnDropper,
     ConstantFilter,
@@ -394,6 +395,47 @@ def test_onehot_drop_first() -> None:
     frame = pd.DataFrame({"c": ["a", "b", "c"] * 20})
     out = OneHotEncoder(["c"], drop_first=True).fit_transform(frame, None, ctx(frame))
     assert list(out.columns) == ["c_b", "c_c"]
+
+
+def test_binary_encoder_distinct_categories_get_distinct_codes() -> None:
+    frame = pd.DataFrame({"c": ["a", "b", "c", "d"]})
+    out = BinaryEncoder(["c"]).fit_transform(frame, None, ctx(frame))
+    codes = [tuple(row) for row in out.to_numpy()]
+    assert len(codes) == len(set(codes))
+
+
+def test_binary_encoder_output_width() -> None:
+    for n in (1, 2, 3, 4, 5, 8, 9):
+        categories = [f"v{i}" for i in range(n)]
+        frame = pd.DataFrame({"c": categories})
+        out = BinaryEncoder(["c"]).fit_transform(frame, None, ctx(frame))
+        expected = int(np.ceil(np.log2(max(n, 1))))
+        assert len([c for c in out.columns if c.startswith("c__bin")]) == expected
+
+
+def test_binary_column_order_is_deterministic() -> None:
+    gen = np.random.default_rng(81)
+    frame = pd.DataFrame({"c": gen.choice(list("dcba"), 100)})
+    a = BinaryEncoder(["c"]).fit_transform(frame, None, ctx(frame))
+    b = BinaryEncoder(["c"]).fit_transform(frame.iloc[::-1], None, ctx(frame))
+    assert list(a.columns) == list(b.columns)
+    assert list(a.columns) == ["c__bin0", "c__bin1"]
+
+
+def test_binary_encoder_unseen_category_is_all_zero() -> None:
+    train = pd.DataFrame({"c": ["a", "b", "c", "d"] * 20})
+    context = ctx(train)
+    encoder = BinaryEncoder(["c"]).fit(train, None, context)
+    out = encoder.transform(pd.DataFrame({"c": ["zzz"]}), context)
+    assert out.to_numpy().tolist() == [[0, 0]]
+
+
+def test_binary_encoder_feature_names_match_columns() -> None:
+    frame = pd.DataFrame({"c": ["a", "b", "c", "d", "e"]})
+    context = ctx(frame)
+    encoder = BinaryEncoder(["c"]).fit(frame, None, context)
+    out = encoder.transform(frame, context)
+    assert list(encoder.get_feature_names_out()) == list(out.columns)
 
 
 def test_ordinal_encoder_honours_an_ordered_categorical() -> None:
@@ -798,6 +840,7 @@ ALL_TRANSFORMERS = [
     OutlierHandler,
     CategoricalEncoder,
     OneHotEncoder,
+    BinaryEncoder,
     OrdinalEncoder,
     FrequencyEncoder,
     RareCategoryGrouper,


### PR DESCRIPTION
Fixes #1

Added `BinaryEncoder` with deterministic binary expansion and wired `encoding="binary"` through `CategoricalEncoder`, with tests covering encoding behavior and feature names.

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.