### PR TITLE
docs: credit TrueFurina for the Codecov failure-mode finding

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ changed what shipped are listed here alongside the commits.
 | [@Jeferson681](https://github.com/Jeferson681) | Made the missing-indicator and high-missing rules see gaps introduced at the cast step ([#16](https://github.com/bijay-odyssey/edaprep/pull/16)) |
 | [@luziyi123448-gif](https://github.com/luziyi123448-gif) | Independent fix for the same issue whose design was the better one; it survives as [#18](https://github.com/bijay-odyssey/edaprep/issues/18) ([#17](https://github.com/bijay-odyssey/edaprep/pull/17)) |
 | [@LeonxLJX](https://github.com/LeonxLJX) | Formatted the tree and made `ruff format` a real CI gate rather than an advisory one ([#25](https://github.com/bijay-odyssey/edaprep/pull/25)) |
+| [@TrueFurina](https://github.com/TrueFurina) | First to run the Codecov upload path, which is how we learned it fails silently from a fork with no token — CI green, nothing reported; coverage moved to the job summary instead ([#21](https://github.com/bijay-odyssey/edaprep/pull/21)) |
 
 [GitHub's contributors graph](https://github.com/bijay-odyssey/edaprep/graphs/contributors)
 counts commits on `main`, so it cannot show a benchmark that settled an argument or a


### PR DESCRIPTION
Follow-up to #21. The coverage change shipped as a job-summary approach, but the finding that made that the right call — Codecov's `codecov-action` failing silently from a fork with no token, CI staying green — was @TrueFurina's, from being the first to actually run it. Adds a row to the Contributors table for it.